### PR TITLE
Unpin @financial-times/n-gage

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "toposort": "^2.0.2"
   },
   "devDependencies": {
-    "@financial-times/n-gage": "3.5.0",
+    "@financial-times/n-gage": "^3.6.0",
     "jest": "^24.7.0"
   }
 }


### PR DESCRIPTION
This pull requests unpins the @financial-times/n-gage dependency. As a general rule we should not be pinning any of our devDependencies.