### PR TITLE
use cross-spawn for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "async-sema": "^3.0.0",
     "byline": "^5.0.0",
     "commander": "^3.0.0",
+    "cross-spawn": "^7.0.1",
     "find-up": "^4.0.0",
     "glob": "^7.1.2",
     "minimatch": "^3.0.4",

--- a/src/spawn.js
+++ b/src/spawn.js
@@ -1,5 +1,5 @@
 const byline = require('byline');
-const { spawn } = require('child_process');
+const spawn = require('cross-spawn');
 
 // npm prefixes each line with ">" which adds a lot of noise
 const cleanLine = (line) => line.toString('utf8').replace(/^>\s+/, '');


### PR DESCRIPTION
For Windows user,  `child_process.spawn()` function should have `shell: true` option.
So I use `cross-spawn` package instead of adding it.

- ✅ works on Windows user who uses `MinGW`
- ✅ also works on Unix