### PR TITLE
🧙 Upgrade rel-engage to 8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "toposort": "^2.0.2"
   },
   "devDependencies": {
-    "@financial-times/rel-engage": "^7.4.3",
+    "@financial-times/rel-engage": "^8.0.1",
     "jest": "^24.7.0"
   }
 }


### PR DESCRIPTION
## Why?

rel-engage has a new major release v8.0. Most of our repos are not using this latest version. The new version includes some previously excluded files to follow similar linting rules.
For more details on changes, see the [v8.0 release notes](https://github.com/Financial-Times/rel-engage/releases/tag/v8.0.0).

## What?

- Updated rel-engage to v8.0 **and** its latest patch version.
- Applied all the new linting changes for code consistency.

### Anything in particular you'd like to highlight to reviewers?

This PR is created automatically using a script. Please double check the changes, since it might have made some unwanted changes.
For any questions regarding this PR, contact us on [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) or email us @ reliability.engineering@ft.com.  

We have used the `[skip ci]` tag in the commit message to prevent an overload of concurrent CircleCI builds. If you would like to run your CI pipeline on this PR, you can make an empty commit on this branch to trigger CI before merging the PR.

`git commit --allow-empty -m "Trigger CI"`