### PR TITLE
Provide credentials for dockerhub image requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ references:
   container_config_node: &container_config_node
     working_directory: ~/project
     docker:
-      - image: circleci/node:8-browsers
+      - image: circleci/node:12-browsers
         <<: *docker-auth
 
   workspace_root: &workspace_root

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,9 @@ workflows:
             - dockerhub-shared
             - rel-eng-creds
       - test:
+          context:
+            - dockerhub-shared
+            - rel-eng-creds
           requires:
             - build
       - ft-snyk-orb/scan-js-packages:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,23 +20,21 @@ references:
       - image: circleci/node:12-browsers
         <<: *docker-auth
 
-  workspace_root: &workspace_root
-    ~/project
+  workspace_root: &workspace_root ~/project
 
   attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
 
-  npm_cache_key: &npm_cache_key
-    cache-v001-{{ .Branch }}-{{ checksum "./package.json" }}
+  npm_cache_key: &npm_cache_key cache-v001-{{ .Branch }}-{{ checksum "./package.json" }}
 
   #
   # Cache creation
   #
   create_cache: &create_cache
     save_cache:
-        key: *npm_cache_key
-        paths:
+      key: *npm_cache_key
+      paths:
         - ./node_modules/
 
   #
@@ -58,7 +56,6 @@ references:
       ignore: /.*/
 
 jobs:
-
   build:
     <<: *container_config_node
     steps:
@@ -101,7 +98,6 @@ jobs:
             make npm-publish
 
 workflows:
-
   build-test-publish:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,13 @@ orbs:
   ft-snyk-orb: financial-times/ft-snyk-orb@0
 
 references:
-
+  #
+  # Authority
+  #
+  docker-auth: &docker-auth
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_ACCESS_TOKEN
   #
   # Workspace
   #
@@ -12,6 +18,7 @@ references:
     working_directory: ~/project
     docker:
       - image: circleci/node:8-browsers
+        <<: *docker-auth
 
   workspace_root: &workspace_root
     ~/project
@@ -98,16 +105,22 @@ workflows:
   build-test-publish:
     jobs:
       - build:
-          context: rel-eng-creds
+          context:
+            - dockerhub-shared
+            - rel-eng-creds
       - test:
           requires:
             - build
       - ft-snyk-orb/scan-js-packages:
-          context: rel-eng-creds
+          context:
+            - dockerhub-shared
+            - rel-eng-creds
           requires:
             - build
       - publish:
-          context: rel-eng-creds
+          context:
+            - dockerhub-shared
+            - rel-eng-creds
           filters:
             <<: *filters_version_tag
           requires:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/Financial-Times/athloi#readme",
   "description": "Athloi is a tool to assist with the management of multi-package repositories (a.k.a. monorepos)",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=12.0.0"
   },
   "dependencies": {
     "async-sema": "^3.0.0",

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,3 @@
 {
-	"extends": ["github>financial-times/renovate-config-next"]
+  "extends": ["github>financial-times/renovate-config-next"]
 }

--- a/test/src/evented-queue.spec.js
+++ b/test/src/evented-queue.spec.js
@@ -49,20 +49,14 @@ describe('src/evented-queue', () => {
 	describe('#waitBehind', () => {
 		it('resolves when the queue no longer contains any of the given items', () => {
 			return new Promise(resolve => {
-				instance
-					.add('foo')
-					.add('bar')
-					.add('baz');
+				instance.add('foo').add('bar').add('baz');
 
 				instance.waitBehind(['foo', 'bar', 'baz']).then(() => {
 					expect(instance.waiting.size).toEqual(0);
 					resolve();
 				});
 
-				instance
-					.delete('foo')
-					.delete('bar')
-					.delete('baz');
+				instance.delete('foo').delete('bar').delete('baz');
 			});
 		});
 	});


### PR DESCRIPTION
## Why?

-   Dockerhub will require authentication from Nov 2020

## What?

-   Define a `docker-auth` reference
-   Use the reference in all `image` requests
-   Ensure each job additionally references the new `docker-shared` context so it has access to the username/passcode

### Anything in particular you'd like to highlight to reviewers?
No