### PR TITLE
Standardise CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @financial-times/reliability-engineering

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,0 @@
-# See https://help.github.com/articles/about-codeowners/ for more information about this file.
-
-* @financial-times/reliability-engineering


### PR DESCRIPTION
## Why?

We want to distribute pull requests around the team more equitably using github's new pull-panda like tooling. To do this, we want a single team added as codeowner for everything.

## What?

Adds a standard codeowners file specifying reliability-engineering as the ownning team.