### PR TITLE
Snyk production scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,7 @@ workflows:
       - test:
           requires:
             - build
+      #Scan package.json for vulnerable dependencies while developing
       - ft-snyk-orb/scan-js-packages:
           context: rel-eng-creds
           requires:
@@ -113,6 +114,14 @@ workflows:
           requires:
             - test
             - ft-snyk-orb/scan-js-packages
+      #Scan and monitor vulnerabilities once in production
+      - ft-snyk-orb/scan-and-monitor-js-packages:
+          name: snyk-scan-and-monitor
+          context: rel-eng-creds
+          requires:
+            - publish
+          filters:
+            <<: *filters_version_tag
 
 experimental:
   notify:

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "toposort": "^2.0.2"
   },
   "devDependencies": {
-    "@financial-times/rel-engage": "^8.0.1",
+    "@financial-times/rel-engage": "^8.0.3",
     "jest": "^24.7.0"
   }
 }


### PR DESCRIPTION
The Reliability Engineering Synk dashboard (https://app.snyk.io/org/reliability-engineering/projects) was not showing any details for `athloi`  since the repo was not been scanned and monitored.

Development level scanning was in place but this has now been extended to include the production level as well.

